### PR TITLE
make notmuch_command global

### DIFF
--- a/autoload/notmuch.vim
+++ b/autoload/notmuch.vim
@@ -9,15 +9,15 @@ function! notmuch#SetupNotmuch() abort
     endif
   endif
 
-  if !exists('s:notmuch_command') 
+  if !exists('g:notmuch_command') 
     if executable('notmuch-addrlookup')
-      let s:notmuch_command = 'notmuch-addrlookup'
+      let g:notmuch_command = 'notmuch-addrlookup'
     elseif executable('notmuch')
-      let s:notmuch_command = 'notmuch address'
+      let g:notmuch_command = 'notmuch address'
     else
       echoerr 'Neither notmuch-addrlookup nor notmuch was found executable.'
       echoerr 'Please install notmuch-addrlookup from https://github.com/aperezdc/notmuch-addrlookup-c or notmuch from https://notmuchmail.org!'
-      let s:notmuch_command = ''
+      let g:notmuch_command = ''
     endif
   endif
 endfunction
@@ -33,8 +33,8 @@ function! notmuch#complete(findstart, base) abort
     return start
   else
     let results = []
-    if !empty(s:notmuch_command)
-      silent let lines = split(system(s:notmuch_command . " '" . a:base . "'"), '\n')
+    if !empty(g:notmuch_command)
+      silent let lines = split(system(g:notmuch_command . " '" . a:base . "'"), '\n')
     endif
 
     if empty(lines)

--- a/doc/notmuch-addrlookup.txt
+++ b/doc/notmuch-addrlookup.txt
@@ -45,6 +45,9 @@ mode. See |i_CTRL-X_CTRL-O| and |compl-omni|.
    If the executable notmuch-addrlookup is unavailable, but notmuch is, then
    notmuch address will be used instead; whose results are however less
    pertinent.
+   Alternative, you can specify the executable with 
+
+    let g:notmuch_command='path to notmuch'
 
 2. Completion is enabled in all mail buffers by default. Add additional file
    types to the list *g:notmuch_filetypes* which defaults to [ 'mail' ]. To


### PR DESCRIPTION
I think it could be convenient for the user (at least for me) to directly specify the notmuch command that shall be invoked.